### PR TITLE
link DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
 
 
 ## References
-Giacomo Marciani, Marco Piu, Michele Porretta, Matteo Nardelli, and Valeria Cardellini. 2016. Real-time analysis of social networks leveraging the flink framework. In *Proceedings of the 10th ACM International Conference on Distributed and Event-based Systems (DEBS '16)*. ACM, New York, NY, USA, 386-389. [DOI](http://dx.doi.org/10.1145/2933267.2933517) [Read here](http://dl.acm.org/citation.cfm?id=2933517)
+Giacomo Marciani, Marco Piu, Michele Porretta, Matteo Nardelli, and Valeria Cardellini. 2016. Real-time analysis of social networks leveraging the flink framework. In *Proceedings of the 10th ACM International Conference on Distributed and Event-based Systems (DEBS '16)*. ACM, New York, NY, USA, 386-389. [DOI](https://doi.org/10.1145/2933267.2933517) [Read here](http://dl.acm.org/citation.cfm?id=2933517)
 
 Giacomo Marciani. 2016. *Marciani Normal Form for Context-free Grammars*. Arxiv. [Read here](https://arxiv.org/abs/1611.01866)
 

--- a/botnet/acmart.cls
+++ b/botnet/acmart.cls
@@ -1174,7 +1174,7 @@ Computing Machinery]
   Copyright held by the owner/author(s). Publication rights licensed to
   ACM\@.
   \fi}
-\def\@formatdoi#1{\url{http://dx.doi.org/#1}}
+\def\@formatdoi#1{\url{https://doi.org/#1}}
 \def\@copyrightpermission{%
   \ifcase\acm@copyrightmode\relax % none
   \or % acmcopyright

--- a/botnet/acmreferences.bst
+++ b/botnet/acmreferences.bst
@@ -612,7 +612,7 @@ FUNCTION { strip.doi } % UTAH
   % "10.1145/1534530.1534545".  That is later typeset and displayed as
   % doi:10.1145/1534530.1534545 as the LAST item in the reference list
   % entry.  Publisher Web sites wrap this with a suitable link to a real
-  % URL to resolve the DOI, and the master http://dx.doi.org/ address is
+  % URL to resolve the DOI, and the master https://doi.org/ address is
   % preferred, since publisher-specific URLs can disappear in response
   % to economic events.  All journals are encouraged by the DOI
   % authorities to use that typeset format and link procedures for
@@ -680,7 +680,7 @@ FUNCTION { output.doi } % UTAH
       %% the presence of the line wrapping, but \path|...| and
       %% \verb|...| do not.
       "\showDOI{%" writeln
-      "\url{http://dx.doi.org/" strip.doi * "}}" * writeln
+      "\url{https://doi.org/" strip.doi * "}}" * writeln
     }
   if$
 }

--- a/lecture-notes/acmlarge.cls
+++ b/lecture-notes/acmlarge.cls
@@ -29,7 +29,7 @@
 %%    feedback from Joanne (Dated 28/06/2010) to simulate print output.
 %% 3) Added newtheorem definition for 'conjecture'
 %% 4) Trimmed the 'double outputting' of the DOI/URL beneath ACM Reference Format (before 1. INTRODUCTION)
-%%    and also beneath the Permission Statement/copyright line. Also inserted the "http://dx.doi.org" stem. (Gerry Murray, March 2012)
+%%    and also beneath the Permission Statement/copyright line. Also inserted the "https://doi.org" stem. (Gerry Murray, March 2012)
 %%
 %% Steps to compile: latex, bibtex, latex latex
 %%
@@ -110,7 +110,7 @@
 \def\@articleSeq{1} %Article sequence
 \def\articleSeq#1{\gdef\@articleSeq{#1}}
 \def\acmArticle#1{\gdef\@acmArticle{#1}}
-\def\@doi{http://dx.doi.org/10.1145/0000000.0000000} % These 'default' '0' values are over-ridden, during production, with 'correct' numbers entered via source .tex file - Gerry March 2012
+\def\@doi{https://doi.org/10.1145/0000000.0000000} % These 'default' '0' values are over-ridden, during production, with 'correct' numbers entered via source .tex file - Gerry March 2012
 
 % ----------------
 % Gerry - April 2011 - To assist in the formatting of the NEW ACM Reference format - 'DOI' in tt font, and url string in default

--- a/lecture-notes/acmreferences.bst
+++ b/lecture-notes/acmreferences.bst
@@ -608,7 +608,7 @@ FUNCTION { strip.doi } % UTAH
   % "10.1145/1534530.1534545".  That is later typeset and displayed as
   % doi:10.1145/1534530.1534545 as the LAST item in the reference list
   % entry.  Publisher Web sites wrap this with a suitable link to a real
-  % URL to resolve the DOI, and the master http://dx.doi.org/ address is
+  % URL to resolve the DOI, and the master https://doi.org/ address is
   % preferred, since publisher-specific URLs can disappear in response
   % to economic events.  All journals are encouraged by the DOI
   % authorities to use that typeset format and link procedures for
@@ -676,7 +676,7 @@ FUNCTION { output.doi } % UTAH
       %% the presence of the line wrapping, but \path|...| and
       %% \verb|...| do not.
       "\showDOI{%" writeln
-      "\url{http://dx.doi.org/" strip.doi * "}}" * writeln
+      "\url{https://doi.org/" strip.doi * "}}" * writeln
     }
   if$
 }

--- a/marciani-normal-form/sig-alternate.cls
+++ b/marciani-normal-form/sig-alternate.cls
@@ -179,7 +179,7 @@
 
 
 \def\doi#1{\def\@doi{#1}}
-\doi{http://dx.doi.org/10.1145/0000000.0000000}
+\doi{https://doi.org/10.1145/0000000.0000000}
 
 \oddsidemargin 4.5pc
 \evensidemargin 4.5pc

--- a/ontoqa/acmart.cls
+++ b/ontoqa/acmart.cls
@@ -1174,7 +1174,7 @@ Computing Machinery]
   Copyright held by the owner/author(s). Publication rights licensed to
   ACM\@.
   \fi}
-\def\@formatdoi#1{\url{http://dx.doi.org/#1}}
+\def\@formatdoi#1{\url{https://doi.org/#1}}
 \def\@copyrightpermission{%
   \ifcase\acm@copyrightmode\relax % none
   \or % acmcopyright

--- a/ontoqa/acmreferences.bst
+++ b/ontoqa/acmreferences.bst
@@ -612,7 +612,7 @@ FUNCTION { strip.doi } % UTAH
   % "10.1145/1534530.1534545".  That is later typeset and displayed as
   % doi:10.1145/1534530.1534545 as the LAST item in the reference list
   % entry.  Publisher Web sites wrap this with a suitable link to a real
-  % URL to resolve the DOI, and the master http://dx.doi.org/ address is
+  % URL to resolve the DOI, and the master https://doi.org/ address is
   % preferred, since publisher-specific URLs can disappear in response
   % to economic events.  All journals are encouraged by the DOI
   % authorities to use that typeset format and link procedures for
@@ -680,7 +680,7 @@ FUNCTION { output.doi } % UTAH
       %% the presence of the line wrapping, but \path|...| and
       %% \verb|...| do not.
       "\showDOI{%" writeln
-      "\url{http://dx.doi.org/" strip.doi * "}}" * writeln
+      "\url{https://doi.org/" strip.doi * "}}" * writeln
     }
   if$
 }

--- a/performance-modeling/acmlarge.cls
+++ b/performance-modeling/acmlarge.cls
@@ -29,7 +29,7 @@
 %%    feedback from Joanne (Dated 28/06/2010) to simulate print output.
 %% 3) Added newtheorem definition for 'conjecture'
 %% 4) Trimmed the 'double outputting' of the DOI/URL beneath ACM Reference Format (before 1. INTRODUCTION)
-%%    and also beneath the Permission Statement/copyright line. Also inserted the "http://dx.doi.org" stem. (Gerry Murray, March 2012)
+%%    and also beneath the Permission Statement/copyright line. Also inserted the "https://doi.org" stem. (Gerry Murray, March 2012)
 %%
 %% Steps to compile: latex, bibtex, latex latex
 %%
@@ -110,7 +110,7 @@
 \def\@articleSeq{1} %Article sequence
 \def\articleSeq#1{\gdef\@articleSeq{#1}}
 \def\acmArticle#1{\gdef\@acmArticle{#1}}
-\def\@doi{http://dx.doi.org/10.1145/0000000.0000000} % These 'default' '0' values are over-ridden, during production, with 'correct' numbers entered via source .tex file - Gerry March 2012
+\def\@doi{https://doi.org/10.1145/0000000.0000000} % These 'default' '0' values are over-ridden, during production, with 'correct' numbers entered via source .tex file - Gerry March 2012
 
 % ----------------
 % Gerry - April 2011 - To assist in the formatting of the NEW ACM Reference format - 'DOI' in tt font, and url string in default

--- a/performance-modeling/acmreferences.bst
+++ b/performance-modeling/acmreferences.bst
@@ -608,7 +608,7 @@ FUNCTION { strip.doi } % UTAH
   % "10.1145/1534530.1534545".  That is later typeset and displayed as
   % doi:10.1145/1534530.1534545 as the LAST item in the reference list
   % entry.  Publisher Web sites wrap this with a suitable link to a real
-  % URL to resolve the DOI, and the master http://dx.doi.org/ address is
+  % URL to resolve the DOI, and the master https://doi.org/ address is
   % preferred, since publisher-specific URLs can disappear in response
   % to economic events.  All journals are encouraged by the DOI
   % authorities to use that typeset format and link procedures for
@@ -676,7 +676,7 @@ FUNCTION { output.doi } % UTAH
       %% the presence of the line wrapping, but \path|...| and
       %% \verb|...| do not.
       "\showDOI{%" writeln
-      "\url{http://dx.doi.org/" strip.doi * "}}" * writeln
+      "\url{https://doi.org/" strip.doi * "}}" * writeln
     }
   if$
 }

--- a/sostream-paper/main.tex
+++ b/sostream-paper/main.tex
@@ -67,7 +67,7 @@
 \setcopyright{rightsretained}
 \conferenceinfo{DEBS '16}{June 20-24, 2016, Irvine, CA, USA}
 \isbn{978-1-4503-4021-2/16/06}
-\doi{http://dx.doi.org/10.1145/2933267.2933517}
+\doi{https://doi.org/10.1145/2933267.2933517}
 
 
 %********************************************************************************

--- a/sostream-paper/ref/sostream.bib
+++ b/sostream-paper/ref/sostream.bib
@@ -41,7 +41,7 @@ series = {DEBS '16}
 	pages = {833--836},
 	publisher = {VLDB Endowment},
 	title = {{Efficient In-memory Data Management: An Analysis}},
-	url = {http://dx.doi.org/10.14778/2732951.2732956},
+	url = {https://doi.org/10.14778/2732951.2732956},
 	volume = {7},
 	year = {2014}
 }

--- a/sostream-paper/sig-alternate-05-2015.cls
+++ b/sostream-paper/sig-alternate-05-2015.cls
@@ -179,7 +179,7 @@
 
 
 \def\doi#1{\def\@doi{#1}}
-\doi{http://dx.doi.org/10.1145/0000000.0000000}
+\doi{https://doi.org/10.1145/0000000.0000000}
 
 \oddsidemargin 4.5pc
 \evensidemargin 4.5pc

--- a/statistics/acmlarge.cls
+++ b/statistics/acmlarge.cls
@@ -29,7 +29,7 @@
 %%    feedback from Joanne (Dated 28/06/2010) to simulate print output.
 %% 3) Added newtheorem definition for 'conjecture'
 %% 4) Trimmed the 'double outputting' of the DOI/URL beneath ACM Reference Format (before 1. INTRODUCTION)
-%%    and also beneath the Permission Statement/copyright line. Also inserted the "http://dx.doi.org" stem. (Gerry Murray, March 2012)
+%%    and also beneath the Permission Statement/copyright line. Also inserted the "https://doi.org" stem. (Gerry Murray, March 2012)
 %%
 %% Steps to compile: latex, bibtex, latex latex
 %%
@@ -110,7 +110,7 @@
 \def\@articleSeq{1} %Article sequence
 \def\articleSeq#1{\gdef\@articleSeq{#1}}
 \def\acmArticle#1{\gdef\@acmArticle{#1}}
-\def\@doi{http://dx.doi.org/10.1145/0000000.0000000} % These 'default' '0' values are over-ridden, during production, with 'correct' numbers entered via source .tex file - Gerry March 2012
+\def\@doi{https://doi.org/10.1145/0000000.0000000} % These 'default' '0' values are over-ridden, during production, with 'correct' numbers entered via source .tex file - Gerry March 2012
 
 % ----------------
 % Gerry - April 2011 - To assist in the formatting of the NEW ACM Reference format - 'DOI' in tt font, and url string in default

--- a/statistics/acmreferences.bst
+++ b/statistics/acmreferences.bst
@@ -608,7 +608,7 @@ FUNCTION { strip.doi } % UTAH
   % "10.1145/1534530.1534545".  That is later typeset and displayed as
   % doi:10.1145/1534530.1534545 as the LAST item in the reference list
   % entry.  Publisher Web sites wrap this with a suitable link to a real
-  % URL to resolve the DOI, and the master http://dx.doi.org/ address is
+  % URL to resolve the DOI, and the master https://doi.org/ address is
   % preferred, since publisher-specific URLs can disappear in response
   % to economic events.  All journals are encouraged by the DOI
   % authorities to use that typeset format and link procedures for
@@ -676,7 +676,7 @@ FUNCTION { output.doi } % UTAH
       %% the presence of the line wrapping, but \path|...| and
       %% \verb|...| do not.
       "\showDOI{%" writeln
-      "\url{http://dx.doi.org/" strip.doi * "}}" * writeln
+      "\url{https://doi.org/" strip.doi * "}}" * writeln
     }
   if$
 }

--- a/thesis-bsc/references/bsc-thesis.bib
+++ b/thesis-bsc/references/bsc-thesis.bib
@@ -929,7 +929,7 @@ queries: running performance, ball possesion, heat map, shot on goal},
   ISSN                     = {00200255},
   Keywords                 = {Big Data,Cloud computing,Data-intensive computing,Parallel and distributed computing,e-Science},
   Publisher                = {Elsevier Inc.},
-  Url                      = {http://dx.doi.org/10.1016/j.ins.2014.01.015}
+  Url                      = {https://doi.org/10.1016/j.ins.2014.01.015}
 }
 
 @InProceedings{Pietzuch2006,


### PR DESCRIPTION
Hello!

The DOI foundation recommends a [new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers :-)